### PR TITLE
Fix `Ambiguous use of '.spotifyAlbumPlaceholder'` compiler error

### DIFF
--- a/SpotifyAPIExampleApp/Views/Album Views/AlbumGridItemView.swift
+++ b/SpotifyAPIExampleApp/Views/Album Views/AlbumGridItemView.swift
@@ -8,7 +8,7 @@ struct AlbumGridItemView: View {
     @EnvironmentObject var spotify: Spotify
     
     /// The cover image for the album.
-    @State private var image = Image(.spotifyAlbumPlaceholder)
+    @State private var image = Image(ImageName.spotifyAlbumPlaceholder)
     
     @State private var loadImageCancellable: AnyCancellable? = nil
     @State private var didRequestImage = false

--- a/SpotifyAPIExampleApp/Views/Album Views/AlbumTracksView.swift
+++ b/SpotifyAPIExampleApp/Views/Album Views/AlbumTracksView.swift
@@ -190,7 +190,7 @@ struct AlbumTracksView_Previews: PreviewProvider {
         NavigationView {
             AlbumTracksView(
                 album: album,
-                image: Image(.spotifyAlbumPlaceholder),
+                image: Image(ImageName.spotifyAlbumPlaceholder),
                 tracks: tracks
             )
             .environmentObject(spotify)

--- a/SpotifyAPIExampleApp/Views/Playlist Views/PlaylistCellView.swift
+++ b/SpotifyAPIExampleApp/Views/Playlist Views/PlaylistCellView.swift
@@ -11,7 +11,7 @@ struct PlaylistCellView: View {
     let playlist: Playlist<PlaylistItemsReference>
 
     /// The cover image for the playlist.
-    @State private var image = Image(.spotifyAlbumPlaceholder)
+    @State private var image = Image(ImageName.spotifyAlbumPlaceholder)
 
     @State private var didRequestImage = false
     


### PR DESCRIPTION
![CleanShot 2024-01-27 at 18 40 38@2x](https://github.com/Peter-Schorn/SpotifyAPIExampleApp/assets/47460844/3bbf2f3a-3eb4-4aef-a36c-7a26201bcce2)

Helping the compiler out a bit here and fixes compiling.